### PR TITLE
Backend/use dotenv

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -33,3 +33,7 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore env files
+.env
+.env*

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -36,6 +36,8 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+gem "dotenv-rails"
+
 gem "alba"
 gem "active_model_serializers"
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -107,6 +107,10 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     drb (2.1.1)
       ruby2_keywords
     erubi (1.12.0)
@@ -265,6 +269,7 @@ DEPENDENCIES
   database_cleaner-active_record
   database_cleaner-redis
   debug
+  dotenv-rails
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -6,6 +6,8 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require 'dotenv/load'
+
 module SwppBackend
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -80,9 +80,8 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     :address              => "smtp.gmail.com",
     :port                 => 587,
-    :user_name            => ENV.fetch("MAIL_USERNAME", "shafshaf.master@gmail.com"),
-    # :password             => ENV.fetch("MAIL_PASSWORD", "yrad bizn txsg uude"),
-    :password             => ENV.fetch("MAIL_PASSWORD", "yradbizntxsguude"),
+    :user_name            => ENV.fetch("MAIL_USERNAME"),
+    :password             => ENV.fetch("MAIL_PASSWORD"),
     :authentication       => "plain",
     :enable_starttls_auto => true
   }


### PR DESCRIPTION
하드코딩된 username, password를 제거하고 `.env` 파일을 이용하도록 합니다.