### PR TITLE
장소 추천에 유저의 마지막 위치를 사용한다

### DIFF
--- a/backend/app/controllers/places_controller.rb
+++ b/backend/app/controllers/places_controller.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class PlacesController < ApplicationController
-  skip_before_action :require_login
-
   def recommend
-    # TODO: User 입력으로 변경하기
-    latitude = params[:latitude].to_f
-    longitude = params[:longitude].to_f
+    user_ids = params[:user_ids].map(&:to_i) + [current_user.id]
+
+    checkins = CheckIn.where(user_id: user_ids).last_check_in_by_user.select(:latitude, :longitude).to_ary
+
+    latitude = checkins.sum { |x| x.latitude } / checkins.size
+    longitude = checkins.sum { |x| x.longitude } / checkins.size
 
     render json: {
       places: RecommendPlaces.new(latitude: latitude, longitude: longitude).run

--- a/backend/app/services/recommend_places.rb
+++ b/backend/app/services/recommend_places.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class RecommendPlaces
-  HOST = 'localhost'
-  PORT = 50051
+  HOST = ENV.fetch("PLACE_SERVICE_HOST") { "localhost" }
+  PORT = ENV.fetch("PLACE_SERVICE_PORT") { 50051 }
 
   def initialize(latitude:, longitude:)
     @latitude = latitude

--- a/backend/spec/controllers/places_controller_spec.rb
+++ b/backend/spec/controllers/places_controller_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlacesController, type: :request do
+  let!(:user) { User.create!(email: "valid@snu.ac.kr", name: "test", password: "1234") }
+  let!(:user2) { User.create!(email: "valid2@snu.ac.kr", name: "test2", password: "1234") }
+  let!(:user3) { User.create!(email: "valid3@snu.ac.kr", name: "test3", password: "1234") }
+
+  before do
+    allow_any_instance_of(Swpp::V1::PlaceService::Stub).to receive(:list_places).and_return(
+      Swpp::V1::ListPlacesResponse.new(place_ids: [1, 2, 3])
+    )
+  end
+
+  describe "GET places/recommend" do
+    context "유저 id 목록을 넘겨주면" do
+      it "그들의 중점으로 요청한다" do
+
+        user.check_in!(latitude: 126.1, longitude: 37.1)
+        user2.check_in!(latitude: 127.1, longitude: 38.1)
+        user3.check_in!(latitude: 128.1, longitude: 39.1)
+
+        get "/places/recommend",
+          headers: auth_header(user),
+          params: {user_ids: [user2.id, user3.id]}
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
장소 추천에서 클라가 넘겨준 `location`, `latitude` 대신 `user_id` 배열을 받아 활용합니다